### PR TITLE
Adding direct support for execution off of global scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist/*
 *.log
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ async function exampleWorker () {
     url: ["URL to Package/Module"]
   })
 
+  // A and T default to unknown
   // To execute method from imported module
   // -> Promise<T | ModuleReturn | void>
-  const result = await worker.runMethod<string>({
+  const result = await worker.runMethod<A, T>({
     method: ["Function name"]
-    module: ["Module Name"]
+    module?: ["Module Name"] // If this is excluded then method executed off of worker global scope
+    args?: A                 // Set the args for type checking :)
   }, async?: boolean)
 
   return result

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.1",
   "author": "Chanceler Shaffer",
   "description": "Class to abstract instantiation of web worker that can load federated modules or any remote script",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shafferchance/federated-worker"
+  },
   "license": "MIT",
   "devDependencies": {
     "ts-loader": "^9.2.6",

--- a/src/workerFederated/federatedWorker.ts
+++ b/src/workerFederated/federatedWorker.ts
@@ -7,6 +7,7 @@ import {
   JobTypes,
   ModuleReturn,
   WorkerEventHandlers,
+  WorkerCallState,
 } from "./types";
 
 import FederatedModuleWorker from "./remoteFederated.worker.ts";
@@ -163,6 +164,17 @@ export class FederatedWorker {
     });
   }
 
+  private routeMethod<T>(type: JobTypes, state: T, wait?: boolean) {
+    if (wait) {
+      return this.runWorkerJob(type, state);
+    } else {
+      this.worker.postMessage({
+        type,
+        state,
+      });
+    }
+  }
+
   addModule(importModuleState: ImportModuleState): Promise<ModuleReturn> {
     if (
       !importModuleState.module ||
@@ -182,16 +194,16 @@ export class FederatedWorker {
   }
 
   runMethod<T>(
-    method: AsyncCallState,
+    methodState: AsyncCallState<T> & WorkerCallState<T>,
     wait?: boolean
   ): Promise<T | ModuleReturn> | void {
-    if (wait) {
-      return this.runWorkerJob("ASYNC_METHOD_CALL", method);
-    } else {
-      this.worker.postMessage({
-        type: "ASYNC_METHOD_CALL",
-        state: method,
-      } as Job<AsyncCallState>);
-    }
+    const { async, module } = methodState;
+    const isAsync = async || wait;
+
+    return this.routeMethod(
+      module ? "ASYNC_METHOD_CALL" : "WORKER_METHOD_CALL",
+      methodState,
+      isAsync
+    );
   }
 }

--- a/src/workerFederated/federatedWorker.ts
+++ b/src/workerFederated/federatedWorker.ts
@@ -193,12 +193,17 @@ export class FederatedWorker {
     );
   }
 
-  runMethod<T>(
-    methodState: AsyncCallState<T> & WorkerCallState<T>,
+  runMethod<A = unknown, T = unknown>(
+    methodState: Omit<AsyncCallState<A>, "module"> &
+      WorkerCallState<A> & { module?: string },
     wait?: boolean
   ): Promise<T | ModuleReturn> | void {
     const { async, module } = methodState;
     const isAsync = async || wait;
+
+    if (this.debug) {
+      console.log(methodState);
+    }
 
     return this.routeMethod(
       module ? "ASYNC_METHOD_CALL" : "WORKER_METHOD_CALL",

--- a/src/workerFederated/remoteFederated.worker.ts
+++ b/src/workerFederated/remoteFederated.worker.ts
@@ -1,45 +1,46 @@
 import {
-    AsyncReturnState,
-    ImportScriptState,
-    Job,
-    Script,
-    WorkerJobHandlers,
-    WorkerJobMessage,
-    WorkerJobs,
+  AsyncReturnState,
+  ImportScriptState,
+  Job,
+  Script,
+  WorkerReturnState,
+  WorkerJobHandlers,
+  WorkerJobMessage,
+  WorkerJobs,
 } from "./types";
 
 declare global {
-    // Interface merging FTW!!!!!!!
-    interface Document {
-        getElementsByTagName(
-            element: "script"
-        ): HTMLCollectionOf<HTMLScriptElement>;
-        createElement(element: "script"): HTMLScriptElement;
-    }
-    interface Window {
-        scripts: Array<Script>;
-        jobs: Record<string, any>;
-        host?: string;
-    }
+  // Interface merging FTW!!!!!!!
+  interface Document {
+    getElementsByTagName(
+      element: "script"
+    ): HTMLCollectionOf<HTMLScriptElement>;
+    createElement(element: "script"): HTMLScriptElement;
+  }
+  interface Window {
+    scripts: Array<Script>;
+    jobs: Record<string, any>;
+    host?: string;
+  }
 
-    interface Window {
-        [scope: string]: {
-            get: <T = any>(module: string) => Promise<T>;
-            init: <T = any>(module: string) => Promise<T>;
-            [method: string]: Function;
-        };
-    }
+  interface Window {
+    [scope: string]: {
+      get: <T = any>(module: string) => Promise<T>;
+      init: <T = any>(module: string) => Promise<T>;
+      [method: string]: Function;
+    };
+  }
 }
 
 function v4UUID() {
-    // https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid
-    // @ts-ignore: I know how strange this looks but it works
-    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-        (
-            c ^
-            (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
-        ).toString(16)
-    );
+  // https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid
+  // @ts-ignore: I know how strange this looks but it works
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+    (
+      c ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+    ).toString(16)
+  );
 }
 
 self.scripts = [];
@@ -47,163 +48,198 @@ self.jobs = [];
 
 // @ts-ignore
 self.document = {
-    ...self.document,
-    head: {
-        appendChild: (childNode: Script) => {
-            try {
-                const jobId = v4UUID();
-                // Might need to make a parent job thing
-                const job: Job<ImportScriptState> = {
-                    type: "IMPORT_SCRIPT_START",
-                    id: jobId,
-                    state: {
-                        url: childNode.src || childNode.getAttribute("src"),
-                        host: self.host,
-                    },
-                };
+  ...self.document,
+  head: {
+    appendChild: (childNode: Script) => {
+      try {
+        const jobId = v4UUID();
+        // Might need to make a parent job thing
+        const job: Job<ImportScriptState> = {
+          type: "IMPORT_SCRIPT_START",
+          id: jobId,
+          state: {
+            url: childNode.src || childNode.getAttribute("src"),
+            host: self.host,
+          },
+        };
 
-                self.jobs[jobId] = () => {
-                    childNode.onload && childNode.onload();
-                };
-                postMessage(job);
-            } catch (e) {
-                console.error(e);
-                childNode.onerror && childNode.onerror(e as Error);
-            }
-        },
-    } as unknown as HTMLHeadElement,
-    getElementsByTagName: (element: "script") => {
-        return self.scripts as unknown as HTMLCollectionOf<HTMLScriptElement>;
+        self.jobs[jobId] = () => {
+          childNode.onload && childNode.onload();
+        };
+        postMessage(job);
+      } catch (e) {
+        console.error(e);
+        childNode.onerror && childNode.onerror(e as Error);
+      }
     },
-    createElement: (element: "script") => {
-        return {
-            src: undefined,
-            attributes: {},
-            getAttribute(attribute: "src") {
-                return this.attributes?.[attribute];
-            },
-            setAttribute(attribute: "src", value: string) {
-                this.attributes[attribute] = value;
-            },
-            onload: undefined,
-            onerror: undefined,
-        } as Script as unknown as HTMLScriptElement;
-    },
+  } as unknown as HTMLHeadElement,
+  getElementsByTagName: (element: "script") => {
+    return self.scripts as unknown as HTMLCollectionOf<HTMLScriptElement>;
+  },
+  createElement: (element: "script") => {
+    return {
+      src: undefined,
+      attributes: {},
+      getAttribute(attribute: "src") {
+        return this.attributes?.[attribute];
+      },
+      setAttribute(attribute: "src", value: string) {
+        this.attributes[attribute] = value;
+      },
+      onload: undefined,
+      onerror: undefined,
+    } as Script as unknown as HTMLScriptElement;
+  },
 };
 
 const handlers: WorkerJobHandlers = {
-    ASYNC_METHOD_CALL: (job) => {
-        const { state, id, parentJob } = job;
-        const { args, async, method, module } = state;
-        if (!self[module]) {
-            throw new Error(`Module [${module}] does not exist`);
+  ASYNC_METHOD_CALL: (job) => {
+    const { state, id, parentJob } = job;
+    const { args, async, method, module } = state;
+    if (!self[module]) {
+      throw new Error(`Module [${module}] does not exist`);
+    }
+
+    if (!self[module][method]) {
+      throw new Error(
+        `Method [${method}] does not exist in Module [${module}]`
+      );
+    }
+
+    let newArgs = Array.isArray(args) ? args : [args];
+
+    // The method it-self might not be async...
+    if (async) {
+      return self[module][method](...newArgs)
+        .then((result: unknown) => {
+          postMessage({
+            type: "ASYNC_METHOD_RETURN",
+            state: {
+              method,
+              module,
+              result,
+            },
+            parentJob,
+            id,
+          } as Job<AsyncReturnState>);
+          return Promise.resolve(true);
+        })
+        .catch((error: Error) => {
+          console.error(error);
+          return Promise.resolve(false);
+        });
+    } else {
+      try {
+        const result = self[module][method](...newArgs);
+        postMessage({
+          type: "ASYNC_METHOD_RETURN",
+          state: {
+            method,
+            module,
+            result,
+          },
+          parentJob,
+          id,
+        } as Job<AsyncReturnState>);
+        if (id) {
+          return true;
         }
+      } catch (e) {
+        console.error(e);
+        return false;
+      }
+    }
+  },
+  IMPORT_MODULE: (job) => {
+    const { state } = job;
+    const { module, scope, url } = state;
+    // Parse Module Map
+    // Order all scripts
+    // Load Federated Module
+    const parsedURL = new URL(url);
 
-        if (!self[module][method]) {
-            throw new Error(
-                `Method [${method}] does not exist in Module [${module}]`
-            );
-        }
+    self.host = parsedURL.host;
 
-        let newArgs = Array.isArray(args) ? args : [args];
+    importScripts(url);
+    self[scope].get
+      .bind(self)(module)
+      .then((remoteModule) => {
+        self[module] = remoteModule();
+        // reset scope so the code know the next can be processed
+        self.host = undefined;
 
-        // The method it-self might not be async...
-        if (async) {
-            return self[module][method](...newArgs)
-                .then((result: unknown) => {
-                    postMessage({
-                        type: "ASYNC_METHOD_RETURN",
-                        state: {
-                            method,
-                            module,
-                            result,
-                        },
-                        parentJob,
-                        id,
-                    } as Job<AsyncReturnState>);
-                    return Promise.resolve(true);
-                })
-                .catch((error: Error) => {
-                    console.error(error);
-                    return Promise.resolve(false);
-                });
-        } else {
-            try {
-                const result = self[module][method](...newArgs);
-                postMessage({
-                    type: "ASYNC_METHOD_RETURN",
-                    state: {
-                        method,
-                        module,
-                        result,
-                    },
-                    parentJob,
-                    id,
-                } as Job<AsyncReturnState>);
-                if (id) {
-                    return true;
-                }
-            } catch (e) {
-                console.error(e);
-                return false;
-            }
-        }
-    },
-    IMPORT_MODULE: (job) => {
-        const { state } = job;
-        const { module, scope, url } = state;
-        // Parse Module Map
-        // Order all scripts
-        // Load Federated Module
-        const parsedURL = new URL(url);
+        postMessage({
+          ...job,
+          type: "IMPORT_MODULE_END",
+          done: true,
+        });
+      });
+  },
+  IMPORT_SCRIPT_START: (job) => {
+    postMessage(job);
+  },
+  IMPORT_SCRIPT_END: (job) => {
+    const { id, state } = job;
+    const { url } = state;
+    if (id && self.jobs[id]) {
+      importScripts(url);
+      self.jobs[id]();
+    } else {
+      importScripts(url);
+    }
+  },
+  WORKER_METHOD_CALL: (job) => {
+    const { state } = job;
+    const { args, method } = state;
 
-        self.host = parsedURL.host;
+    if (!self[method]) {
+      throw new Error("Method doesn't exist");
+    }
 
-        importScripts(url);
-        self[scope].get
-            .bind(self)(module)
-            .then((remoteModule) => {
-                self[module] = remoteModule();
-                // reset scope so the code know the next can be processed
-                self.host = undefined;
+    // @ts-ignore: Will find better typing in the future
+    const rawResult = self[method](...args);
 
-                postMessage({
-                    ...job,
-                    type: "IMPORT_MODULE_END",
-                    done: true,
-                });
-            });
-    },
-    IMPORT_SCRIPT_START: (job) => {
-        postMessage(job);
-    },
-    IMPORT_SCRIPT_END: (job) => {
-        const { id, state } = job;
-        const { url } = state;
-        if (id && self.jobs[id]) {
-            importScripts(url);
-            self.jobs[id]();
-        } else {
-            importScripts(url);
-        }
-    },
+    if (rawResult?.then) {
+      rawResult.then((res: unknown) => {
+        const asyncResult: Job<WorkerReturnState> = {
+          type: "WORKER_METHOD_RETURN",
+          state: {
+            method,
+            result: res,
+          },
+        };
+
+        postMessage(asyncResult);
+      });
+    } else {
+      const syncResult: Job<WorkerReturnState> = {
+        type: "WORKER_METHOD_RETURN",
+        state: {
+          method,
+          result: rawResult,
+        },
+      };
+
+      postMessage(syncResult);
+    }
+  },
 };
 
 onmessage = (workerEvent: WorkerJobMessage) => {
-    const { type } = workerEvent.data;
+  const { type } = workerEvent.data;
 
-    const handler = handlers[type as WorkerJobs];
+  const handler = handlers[type as WorkerJobs];
 
-    if (!handler) {
-        throw new Error(`No handler found for Job [${type}]`);
-    }
+  if (!handler) {
+    throw new Error(`No handler found for Job [${type}]`);
+  }
 
-    try {
-        // TODO: Job State mgmt
-        // @ts-ignore: Why have all the extra code of the switch if we can do the same with an ignore 🤷‍♂️
-        handler(workerEvent.data);
-    } catch (e) {
-        // Extra layer of protection
-        console.error(e);
-    }
+  try {
+    // TODO: Job State mgmt
+    // @ts-ignore: Why have all the extra code of the switch if we can do the same with an ignore 🤷‍♂️
+    handler(workerEvent.data);
+  } catch (e) {
+    // Extra layer of protection
+    console.error(e);
+  }
 };

--- a/src/workerFederated/remoteFederated.worker.ts
+++ b/src/workerFederated/remoteFederated.worker.ts
@@ -199,6 +199,7 @@ const handlers: WorkerJobHandlers = {
     // @ts-ignore: Will find better typing in the future
     const rawResult = self[method](...args);
 
+    // Best practice per spec is to check for thenable rather than instanceof promise
     if (rawResult?.then) {
       rawResult.then((res: unknown) => {
         const asyncResult: Job<WorkerReturnState> = {
@@ -220,6 +221,7 @@ const handlers: WorkerJobHandlers = {
         },
       };
 
+      // Perhaps should make this optional to save on serialization overhead?
       postMessage(syncResult);
     }
   },

--- a/src/workerFederated/remoteFederated.worker.ts
+++ b/src/workerFederated/remoteFederated.worker.ts
@@ -226,7 +226,8 @@ const handlers: WorkerJobHandlers = {
 };
 
 onmessage = (workerEvent: WorkerJobMessage) => {
-  const { type } = workerEvent.data;
+  const { data } = workerEvent;
+  const { type } = data;
 
   const handler = handlers[type as WorkerJobs];
 
@@ -237,7 +238,7 @@ onmessage = (workerEvent: WorkerJobMessage) => {
   try {
     // TODO: Job State mgmt
     // @ts-ignore: Why have all the extra code of the switch if we can do the same with an ignore 🤷‍♂️
-    handler(workerEvent.data);
+    handler(data);
   } catch (e) {
     // Extra layer of protection
     console.error(e);

--- a/src/workerFederated/types.ts
+++ b/src/workerFederated/types.ts
@@ -37,17 +37,30 @@ export type AsyncReturnState<T = unknown> = {
   result?: T;
 };
 
+export type WorkerCallState<T = unknown> = {
+  method: string;
+  async?: boolean;
+  args?: T;
+};
+
+export type WorkerReturnState<T = unknown> = {
+  method: string;
+  result?: T;
+};
+
 export type JobTypes =
   | "IMPORT_SCRIPT_START"
   | "IMPORT_SCRIPT_END"
   | "IMPORT_MODULE"
   | "IMPORT_MODULE_END"
   | "ASYNC_METHOD_CALL"
-  | "ASYNC_METHOD_RETURN";
+  | "ASYNC_METHOD_RETURN"
+  | "WORKER_METHOD_CALL"
+  | "WORKER_METHOD_RETURN";
 
 export type WorkerJobs = Exclude<
   JobTypes,
-  "ASYNC_METHOD_RETURN" | "IMPORT_MODULE_END"
+  "ASYNC_METHOD_RETURN" | "IMPORT_MODULE_END" | "WORKER_METHOD_RETURN"
 >;
 
 export interface Job<T> {
@@ -65,6 +78,8 @@ export class JobStatePerType implements Record<JobTypes, unknown> {
   IMPORT_MODULE_END!: ImportModuleState;
   ASYNC_METHOD_CALL!: AsyncCallState;
   ASYNC_METHOD_RETURN!: AsyncReturnState;
+  WORKER_METHOD_CALL!: WorkerCallState;
+  WORKER_METHOD_RETURN!: WorkerReturnState;
 }
 
 export type WorkerJobHandlers = {


### PR DESCRIPTION
***I do recognize this could lead to some information being dumped that you may not want to be dumped. Might add a `blacklist` that has a default set of functions that cannot be executed in the future but for now I will exclude this.***

# Purpose
This unlocks the full power of composed workers. While it was possible before there needed to be a wrapper around the library with an entry on the global scope. Which seems to be a common pattern anyhow among libraries, but just in case now you can call methods directly from the global scope.


